### PR TITLE
Fix support for Node 0.10 which was broken by #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,19 +2,30 @@
 // much λ, much UX.
 module.exports = function λ(fn) {
   return function(e, ctx, cb) {
+    var succeed, fail;
+    // cb will be defined for node 4.3 on lambda
+    if (cb) {
+      succeed = function(result) {
+        cb(null, result)
+      }
+      fail = function(err) {
+        cb(err)
+      }
+    } else {
+      succeed = ctx.succeed, fail = ctx.fail;
+    }
+
     try {
       var v = fn(e, ctx, cb)
 
       if (v && typeof v.then == 'function') {
-        v.then(function (val) {
-            cb(null, val)
-        }).catch(cb)
+        v.then(succeed).catch(fail)
         return
       }
 
-      cb(null, v)
+      succeed(v)
     } catch (err) {
-      cb(err)
+      fail(err)
     }
   }
 }


### PR DESCRIPTION
While it was nice that #3 added support for Node 4.3 on Lambda, it totally broke Node 0.10 on Lambda causing requests with errors to time out.

This PR fixes it so this module works with both.
