### PR TITLE
fix accidental promise wrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,14 @@ module.exports = function λ(fn) {
 
       if (v && typeof v.then == 'function') {
         v.then(function (val) {
+          process.nextTick(function () {
             cb(null, val)
-        }).catch(cb)
+          })
+        }).catch(function (err) {
+          process.nextTick(function () {
+            cb(err)
+          })
+        })
         return
       }
 


### PR DESCRIPTION
The callbacks of promise.{then,catch} are still wrapped in the
promise's try/catch block. We break out of it to prevent unexpected
behavior, like in the case of

```js
module.exports({}, {}, function (err) {
  if (err) throw err
  console.log('ok')
})
```

The `throw err` will be caught by the promise and instead of the
error being properly thrown, we get an uncaught promise warning.